### PR TITLE
Fix model loading and device setup

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -125,8 +125,7 @@ def main(
 
     print(f"Loading model")
     model, tokenizer = load_hf_model(model_path, device)
-    print("Loading model.to(device)")
-    model = model.to(device).eval()
+    model = model.eval()
 
     num_image_tokens = model.config.vision_config.num_image_tokens
     image_size = model.config.vision_config.image_size


### PR DESCRIPTION
## Summary
- load safetensors using `load_file` and move model after tying weights
- avoid calling `.to(device)` twice in inference script

## Testing
- `python inference.py --help` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68779db3506c8333ae9dff4cfbfb4cb0